### PR TITLE
update import script to load data from WCS using api key

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "import.py",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": [
+                "../weaviate-io/",
+                "developers",
+                "blog"
+            ]
+        }
+    ]
+}

--- a/import.py
+++ b/import.py
@@ -5,11 +5,9 @@ import sys
 import weaviate
 from bs4 import BeautifulSoup
 
-WEAVIATE_LOGIN = os.environ['WEAVIATE_LOGIN']
-WEAVIATE_PASS = os.environ['WEAVIATE_PASS']
-WEAVIATE_HOST = os.environ['WEAVIATE_HOST']
+WCS_HOST = os.environ['WCS_HOST']
+WCS_KEY = os.environ['WCS_KEY']
 OPENAI_APIKEY = os.environ['OPENAI_APIKEY']
-
 
 def replace_url_to_link(s):
     s = re.sub(r'[^a-zA-Z0-9_ ]', '', s)
@@ -238,10 +236,12 @@ if __name__ == "__main__":
         exit(1)
 
     try:
+        auth_config = weaviate.AuthApiKey(api_key=WCS_KEY)
+
         client = weaviate.Client(
-            url=WEAVIATE_HOST,
+            url=WCS_HOST,
+            auth_client_secret=auth_config,
             timeout_config=600,
-            auth_client_secret=weaviate.AuthClientPassword(WEAVIATE_LOGIN, WEAVIATE_PASS),
             additional_headers={
                 "X-OpenAI-Api-Key": OPENAI_APIKEY
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.11.1
 marko==1.2.2
-weaviate-client>=3.11.0
+weaviate-client==3.25.3


### PR DESCRIPTION
## Before merge
We need to add the following github secrets (which should provide the way to access the new WCS cluster):
* `WCS_HOST`
* `WCS_KEY` – write key 

## After merge:

**Step 1a** 
Update the domain address for `https://search.weaviate.io` to point to the new WCS cluster.

**Step 1b** 
Update `CommandMenu/query.js` in the [weaviate-io project](https://github.com/weaviate/weaviate-io/blob/fca08fa1953900d249cdfcd30bf6f83d0fce4231/src/components/CommandMenu/query.js#L22), so that the queries would be sent to the new WCS instance:
* add the Authorization with the read-only WCS key
    ```
    'Authorization': 'Bearer ADD-WCS-READ-ONLY-KEY-HERE' // read-only key
    ```

**Step 2**
Remove env variables from the github secrets:
* `WEAVIATE_HOST`
* `WEAVIATE_LOGIN`
* `WEAVIATE_PASS`
